### PR TITLE
宝くじ関連のAPIを追加

### DIFF
--- a/app/Http/Controllers/LotteryController.php
+++ b/app/Http/Controllers/LotteryController.php
@@ -11,7 +11,7 @@ use Illuminate\Http\Request;
 
 use function PHPUnit\Framework\isEmpty;
 
-const MIN_ACHIEVEMENTS = 1;//5;
+const MIN_ACHIEVEMENTS = 15;
 
 class LotteryController extends Controller
 {
@@ -26,6 +26,7 @@ class LotteryController extends Controller
             "is_voted" => $is_voted
         ], Response::HTTP_OK);
     }
+
     public function vote(Request $request){
         $user = $request->user();
         $user_id = $user->id;
@@ -52,6 +53,7 @@ class LotteryController extends Controller
             return response()->json(['message' => 'Error occured'], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
+
     public function get_winner(Request $request){
         $user = $request->user();
 

--- a/app/Http/Controllers/LotteryController.php
+++ b/app/Http/Controllers/LotteryController.php
@@ -9,17 +9,69 @@ use Illuminate\Support\Facades\DB;
 use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Http\Request;
 
-const MIN_ACHIEVEMENTS = 15;
+use function PHPUnit\Framework\isEmpty;
+
+const MIN_ACHIEVEMENTS = 1;//5;
 
 class LotteryController extends Controller
 {
     public function user_status(Request $request){
         $user = $request->user();
         $achievements_count = $user->achievements()->count();
+        $is_voted = $user->vote()->exists();
 
         return response()->json([
             'is_admin' => ($user->is_admin == 1),
-            "can_vote" => ($achievements_count >= MIN_ACHIEVEMENTS)
-        ]);
+            "can_vote" => ($achievements_count >= MIN_ACHIEVEMENTS && ! $is_voted),
+            "is_voted" => $is_voted
+        ], Response::HTTP_OK);
+    }
+    public function vote(Request $request){
+        $user = $request->user();
+        $user_id = $user->id;
+
+        $achievements_count = $user->achievements()->count();
+        $is_voted = $user->vote()->exists();
+
+        if ($achievements_count < MIN_ACHIEVEMENTS){
+            return response()->json(['message' => 'Achievements is not enough'], Response::HTTP_BAD_REQUEST);
+        }
+        if ($is_voted){
+            return response()->json(['message' => 'Already voted'], Response::HTTP_BAD_REQUEST);
+        }
+        
+        DB::beginTransaction();
+        try {
+            $user->vote()->create(['voted_number' => $request->voted_number]);
+            DB::commit();
+
+            return response()->json(['message' => 'OK'], Response::HTTP_OK);
+        } catch (\Exception $e) {
+            DB::rollback();
+
+            return response()->json(['message' => 'Error occured'], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+    public function get_winner(Request $request){
+        $user = $request->user();
+
+        if ( ! $user->is_admin){
+            return response()->json(['message' => 'You are not admin'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $win_vote = Vote::groupBy('voted_number')
+                ->select('voted_number', DB::raw('count(*) as voted_count'))
+                ->having('voted_count', 1)
+                ->orderBy('voted_number')
+                ->first();
+        
+        if ($win_vote === null){
+            return response()->json(['message' => 'No one won'], Response::HTTP_OK);
+        }
+
+        $win_number = $win_vote->voted_number;
+        $winner_id = Vote::where("voted_number", $win_number)->first()->user->id;
+
+        return response()->json(['user_id' => $winner_id, 'win_number' => $win_number], Response::HTTP_OK);
     }
 }

--- a/app/Http/Controllers/LotteryController.php
+++ b/app/Http/Controllers/LotteryController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Vote;
+use App\Models\Achievement;
+use PhpParser\Node\Expr\FuncCall;
+use Illuminate\Support\Facades\DB; 
+use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Http\Request;
+
+const MIN_ACHIEVEMENTS = 15;
+
+class LotteryController extends Controller
+{
+    public function user_status(Request $request){
+        $user = $request->user();
+        $achievements_count = $user->achievements()->count();
+
+        return response()->json([
+            'is_admin' => ($user->is_admin == 1),
+            "can_vote" => ($achievements_count >= MIN_ACHIEVEMENTS)
+        ]);
+    }
+}

--- a/database/migrations/2021_08_18_034903_create_votes_table.php
+++ b/database/migrations/2021_08_18_034903_create_votes_table.php
@@ -19,7 +19,7 @@ class CreateVotesTable extends Migration
             $table->unsignedBigInteger("voted_number");
             $table->timestamps();
             
-            $table->primary(['user_id'],'id');
+            $table->primary(['user_id'],'user_id');
         });
     }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,7 +6,7 @@ use App\Http\Controllers\Api\Auth\RegisterController;
 use App\Http\Controllers\Api\Auth\LoginController;
 use App\Http\Controllers\TaskController;
 use App\Http\Controllers\AchievementController;
-
+use App\Http\Controllers\LotteryController;
 /*
 |--------------------------------------------------------------------------
 | API Routes
@@ -26,3 +26,4 @@ Route::post('/register', [RegisterController::class, 'register']);
 Route::post('/login', [LoginController::class, 'login']);
 Route::middleware('auth:sanctum')->get('/tasks', [TaskController::class, 'getTasks']);
 Route::middleware('auth:sanctum')->put('/achievements', [AchievementController::class, 'putAchievements']);
+Route::middleware('auth:sanctum')->get('/user/lottery', [LotteryController::class, 'user_status']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -27,3 +27,5 @@ Route::post('/login', [LoginController::class, 'login']);
 Route::middleware('auth:sanctum')->get('/tasks', [TaskController::class, 'getTasks']);
 Route::middleware('auth:sanctum')->put('/achievements', [AchievementController::class, 'putAchievements']);
 Route::middleware('auth:sanctum')->get('/user/lottery', [LotteryController::class, 'user_status']);
+Route::middleware('auth:sanctum')->post('/vote', [LotteryController::class, 'vote']);
+Route::middleware('auth:sanctum')->get('/winner', [LotteryController::class, 'get_winner']);


### PR DESCRIPTION
## やったこと
宝くじ関連のAPI
- ユーザの宝くじに関するステータス取得
  - Path: /api/user/lottery
  - Method: GET
- 宝くじに応募
  - Path: /api/vote
  - Method: POST
- 当選者、当選番号取得
  - Path: /api/winner
  - Method: GET
  
## やらないこと
- Serviceの使用（必須API実装後やります）

## 動作確認
### ユーザの宝くじに関するステータス取得
- リクエスト
    - なし
- レスポンス
  ~~~
  {
      "is_admin": false,
      "can_vote": true,
      "is_voted": false
  }
  ~~~
### 宝くじ応募
- リクエスト
  ~~~
  {
      "voted_number" : 100
  }
  ~~~
- レスポンス
  ~~~
  {
      "message": "OK"
  }
  ~~~
### 当選者、当選番号取得
- リクエスト
    - なし
- レスポンス
  ~~~
  {
      "user_id": 13,
      "win_number": 100
  }
  ~~~